### PR TITLE
fix: use Image field thumbnail names from model in higher-level value types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -228,8 +228,8 @@ type CustomTypeModelFieldForGroupValue<
 	? prismicT.TitleField<State>
 	: T extends prismicT.CustomTypeModelRichTextField
 	? prismicT.RichTextField<State>
-	: T extends prismicT.CustomTypeModelImageField
-	? prismicT.ImageField<string | null, State>
+	: T extends prismicT.CustomTypeModelImageField<infer TThumbnailNames>
+	? prismicT.ImageField<TThumbnailNames, State>
 	: T extends prismicT.CustomTypeModelLinkField
 	? prismicT.LinkField<string, string, never, State>
 	: T extends prismicT.CustomTypeModelLinkToMediaField


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a type issue where thumbnail names from a typed Image field model would not be passed to a generated Image field value. The issue only occurs when a high-level value is generated, like a document or Group field value.

```typescript
import { createMockFactory } from "@prismicio/mock";

const mock = createMockFactory({ seed: "foo" });

const model = mock.model.customType({
  fields: {
    image: mock.model.image({ thumbnailNames: ["foo", "bar"] }),
  },
})

const value = mock.value.document({ model });
```

Before this PR, `value.data.image` would not include `foo` and `bar` properties in its type (the runtime value would include it, however).

After this PR, `value.data.image` includes `foo` and `bar` properties in its type, inferred from the provided model.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
