### PR TITLE
fix: use Rich Text field type for Rich Text and Title field values

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -224,10 +224,10 @@ type CustomTypeModelFieldForGroupValue<
 	? prismicT.BooleanField
 	: T extends prismicT.CustomTypeModelColorField
 	? prismicT.ColorField<State>
-	: T extends prismicT.CustomTypeModelTitleField
-	? prismicT.TitleField<State>
 	: T extends prismicT.CustomTypeModelRichTextField
 	? prismicT.RichTextField<State>
+	: T extends prismicT.CustomTypeModelTitleField
+	? prismicT.TitleField<State>
 	: T extends prismicT.CustomTypeModelImageField<infer TThumbnailNames>
 	? prismicT.ImageField<TThumbnailNames, State>
 	: T extends prismicT.CustomTypeModelLinkField


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where Rich Text field values were typed as Title fields. The issue only occurs when a high-level value is generated, like a document or Group field value.

```typescript
import { createMockFactory } from "@prismicio/mock";

const mock = createMockFactory({ seed: "foo" });

const model = mock.model.customType({
  fields: {
    richText: mock.model.richText(),
  },
});

const value = mock.value.document({ model });
```

Before this PR, `value.data.richText` would be typed as `TitleField`.

After this PR, `value.data.title` is typed as `RichTextField`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
