### PR TITLE
fix: restore types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 			"devDependencies": {
 				"@prismicio/client": "^7.0.1",
 				"@size-limit/preset-small-lib": "^8.2.4",
+				"@types/node": "^20.3.0",
 				"@typescript-eslint/eslint-plugin": "^5.59.8",
 				"@typescript-eslint/parser": "^5.59.8",
 				"ava": "^5.3.0",
@@ -1278,6 +1279,12 @@
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "20.3.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+			"integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -8989,6 +8996,12 @@
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "20.3.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+			"integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 		"release:alpha:dry": "standard-version --release-as major --prerelease alpha --dry-run",
 		"release:dry": "standard-version --dry-run",
 		"size": "size-limit",
-		"test": "npm run lint && npm run unit && npm run build && npm run size",
+		"test": "npm run lint && npm run types && npm run unit && npm run build && npm run size",
+		"types": "tsc --noEmit",
 		"unit": "nyc --reporter=lcovonly --reporter=text --exclude-after-remap=false ava"
 	},
 	"dependencies": {
@@ -62,6 +63,7 @@
 	"devDependencies": {
 		"@prismicio/client": "^7.0.1",
 		"@size-limit/preset-small-lib": "^8.2.4",
+		"@types/node": "^20.3.0",
 		"@typescript-eslint/eslint-plugin": "^5.59.8",
 		"@typescript-eslint/parser": "^5.59.8",
 		"ava": "^5.3.0",

--- a/src/lib/valueForModelMap.ts
+++ b/src/lib/valueForModelMap.ts
@@ -92,7 +92,7 @@ const getValueConfigType = <Model extends prismic.CustomTypeModelField>(
 		case prismic.CustomTypeModelFieldType.UID:
 			return "uid";
 
-		case prismic.CustomTypeModelFieldType.IntegrationField:
+		case prismic.CustomTypeModelFieldType.Integration:
 			return "integration";
 
 		case prismic.CustomTypeModelFieldType.Slices:

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,18 +178,18 @@ export type ModelValue<
 	: T extends prismic.CustomTypeModelSliceZoneField
 	? prismic.SliceZone<
 			ValueOf<{
-				[P in keyof NonNullable<T["config"]>["choices"] as P extends string
-					? P
-					: never]: NonNullable<
-					T["config"]
-				>["choices"][P] extends prismic.CustomTypeModelSlice
+				[P in keyof NonNullable<
+					NonNullable<T["config"]>["choices"]
+				> as P extends string ? P : never]: NonNullable<
+					NonNullable<T["config"]>["choices"]
+				>[P] extends prismic.CustomTypeModelSlice
 					? CustomTypeModelSliceValue<
-							NonNullable<T["config"]>["choices"][P],
+							NonNullable<NonNullable<T["config"]>["choices"]>[P],
 							P extends string ? P : string
 					  >
 					: NonNullable<
-							T["config"]
-					  >["choices"][P] extends prismic.CustomTypeModelSharedSlice
+							NonNullable<T["config"]>["choices"]
+					  >[P] extends prismic.CustomTypeModelSharedSlice
 					? prismic.SharedSlice<P extends string ? P : string>
 					: never;
 			}>,

--- a/src/value/link.ts
+++ b/src/value/link.ts
@@ -39,7 +39,7 @@ type MockLinkValue<
 	: LinkType extends typeof prismic.LinkType.Media
 	? prismic.FilledLinkToMediaField
 	: LinkType extends typeof prismic.LinkType.Document
-	? prismic.FilledLinkToDocumentField
+	? prismic.FilledContentRelationshipField
 	: never;
 
 export const link = <

--- a/test/model-contentRelationship.test.ts
+++ b/test/model-contentRelationship.test.ts
@@ -21,7 +21,7 @@ test("can be configured to constrain by custom type", (t) => {
 		customTypeIDs,
 	});
 
-	t.is(actual.config.customtypes, customTypeIDs);
+	t.is(actual.config?.customtypes, customTypeIDs);
 });
 
 test("can be configured to constrain by tags", (t) => {
@@ -31,5 +31,5 @@ test("can be configured to constrain by tags", (t) => {
 		tags,
 	});
 
-	t.is(actual.config.tags, tags);
+	t.is(actual.config?.tags, tags);
 });

--- a/test/model-group.test.ts
+++ b/test/model-group.test.ts
@@ -22,7 +22,7 @@ test("can be configured for specific fields", (t) => {
 	});
 
 	t.is(
-		actual.config.fields.boolean.type,
+		actual.config?.fields?.boolean.type,
 		prismic.CustomTypeModelFieldType.Boolean,
 	);
 });

--- a/test/model-image.test.ts
+++ b/test/model-image.test.ts
@@ -18,8 +18,8 @@ test("can be configured to include constraints", (t) => {
 		withConstraint: true,
 	});
 
-	t.is(typeof actual.config.constraint.width, "number");
-	t.is(typeof actual.config.constraint.height, "number");
+	t.is(typeof actual.config?.constraint?.width, "number");
+	t.is(typeof actual.config?.constraint?.height, "number");
 });
 
 test("can be configured for a specific thumbnails", (t) => {
@@ -28,6 +28,6 @@ test("can be configured for a specific thumbnails", (t) => {
 		thumbnailNames: ["Foo"],
 	});
 
-	t.is(actual.config.thumbnails.length, 1);
-	t.is(actual.config.thumbnails[0].name, "Foo");
+	t.is(actual.config?.thumbnails?.length, 1);
+	t.is(actual.config?.thumbnails?.[0].name, "Foo");
 });

--- a/test/model-select.test.ts
+++ b/test/model-select.test.ts
@@ -19,7 +19,7 @@ test("can be configured for a specific options", (t) => {
 		options,
 	});
 
-	t.is(actual.config.options, options);
+	t.is(actual.config?.options, options);
 });
 
 test("can be configured for a specific default value", (t) => {
@@ -29,5 +29,5 @@ test("can be configured for a specific default value", (t) => {
 		defaultValue: "foo",
 	});
 
-	t.is(actual.config.default_value, "foo");
+	t.is(actual.config?.default_value, "foo");
 });

--- a/test/model-sharedSliceVariation.test.ts
+++ b/test/model-sharedSliceVariation.test.ts
@@ -57,6 +57,6 @@ test("can be configured for specific primary and items fields", (t) => {
 		},
 	});
 
-	t.is(actual.primary.boolean.type, prismic.CustomTypeModelFieldType.Boolean);
-	t.is(actual.items.keyText.type, prismic.CustomTypeModelFieldType.Text);
+	t.is(actual.primary?.boolean.type, prismic.CustomTypeModelFieldType.Boolean);
+	t.is(actual.items?.keyText.type, prismic.CustomTypeModelFieldType.Text);
 });

--- a/test/model-slice.test.ts
+++ b/test/model-slice.test.ts
@@ -25,8 +25,8 @@ test("can be configured for specific non-repeat and repeat fields", (t) => {
 	});
 
 	t.is(
-		actual["non-repeat"].boolean.type,
+		actual["non-repeat"]?.boolean.type,
 		prismic.CustomTypeModelFieldType.Boolean,
 	);
-	t.is(actual.repeat.keyText.type, prismic.CustomTypeModelFieldType.Text);
+	t.is(actual.repeat?.keyText.type, prismic.CustomTypeModelFieldType.Text);
 });

--- a/test/model-sliceZone.test.ts
+++ b/test/model-sliceZone.test.ts
@@ -23,5 +23,5 @@ test("can be configured to use specific choices", (t) => {
 		choices,
 	});
 
-	t.deepEqual(actual.config.choices, choices);
+	t.deepEqual(actual.config?.choices, choices);
 });

--- a/test/value-contentRelationship.test.ts
+++ b/test/value-contentRelationship.test.ts
@@ -28,10 +28,10 @@ test("supports custom model", (t) => {
 	});
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	t.true(customModel.config.customtypes!.includes(actual.type));
+	t.true(customModel.config?.customtypes!.includes(actual.type));
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	t.true(customModel.config.tags!.every((tag) => actual.tags.includes(tag)));
+	t.true(customModel.config?.tags!.every((tag) => actual.tags.includes(tag)));
 });
 
 test("can be configured to return an empty value", (t) => {
@@ -67,8 +67,10 @@ test("can be configured to return a link from a given list of documents with con
 	];
 
 	const customModel = model.contentRelationship({ seed: t.title });
-	customModel.config.customtypes = ["foo"];
-	customModel.config.tags = ["bar"];
+	if (customModel.config) {
+		customModel.config.customtypes = ["foo"];
+		customModel.config.tags = ["bar"];
+	}
 
 	const actual = value.contentRelationship({
 		seed: t.title,
@@ -89,8 +91,10 @@ test("throws if a linkable document cannot be found within constraints", (t) => 
 	];
 
 	const customModel = model.contentRelationship({ seed: t.title });
-	customModel.config.customtypes = ["foo"];
-	customModel.config.tags = ["bar"];
+	if (customModel.config) {
+		customModel.config.customtypes = ["foo"];
+		customModel.config.tags = ["bar"];
+	}
 
 	t.throws(
 		() =>

--- a/test/value-image.test.ts
+++ b/test/value-image.test.ts
@@ -15,13 +15,15 @@ test("supports number seed", snapshotTwiceMacro, () =>
 
 test("can be configured to return an empty value", (t) => {
 	const customModel = model.image({ seed: t.title });
-	customModel.config.thumbnails = [
-		{
-			name: "Foo",
-			height: null,
-			width: null,
-		},
-	];
+	if (customModel.config) {
+		customModel.config.thumbnails = [
+			{
+				name: "Foo",
+				height: null,
+				width: null,
+			},
+		];
+	}
 
 	const actual = value.image({
 		seed: t.title,
@@ -29,23 +31,18 @@ test("can be configured to return an empty value", (t) => {
 		state: "empty",
 	});
 
-	t.deepEqual(
-		actual,
-		// TODO: Resolve the following type error
-		// @ts-expect-error - Unsure how to fix this type mismatch
-		{
+	t.deepEqual(actual, {
+		url: null,
+		alt: null,
+		copyright: null,
+		dimensions: null,
+		Foo: {
 			url: null,
 			alt: null,
 			copyright: null,
 			dimensions: null,
-			Foo: {
-				url: null,
-				alt: null,
-				copyright: null,
-				dimensions: null,
-			},
 		},
-	);
+	});
 });
 
 test("supports custom model", (t) => {
@@ -60,7 +57,13 @@ test("supports custom model", (t) => {
 		model: customModel,
 	});
 
-	t.is(actual.dimensions.width, customModel.config.constraint.width);
-	t.is(actual.dimensions.height, customModel.config.constraint.height);
+	t.is(
+		actual.dimensions.width,
+		customModel.config?.constraint?.width as number,
+	);
+	t.is(
+		actual.dimensions.height,
+		customModel.config?.constraint?.height as number,
+	);
 	t.true("Foo" in actual);
 });

--- a/test/value-richText.test.ts
+++ b/test/value-richText.test.ts
@@ -18,14 +18,19 @@ test("supports custom model", (t) => {
 		seed: t.title,
 		withMultipleBlocks: false,
 	});
-	customModel.config.single = "paragraph";
+	if (customModel.config) {
+		customModel.config.single = "paragraph";
+	}
 
 	const actual = value.richText({
 		seed: t.title,
 		model: customModel,
 	});
 
-	t.is(actual[0].type, customModel.config.single);
+	t.is(
+		actual[0]?.type,
+		customModel.config?.single as (typeof actual)[number]["type"],
+	);
 });
 
 test("models without multiple blocks returns one block", (t) => {
@@ -33,7 +38,9 @@ test("models without multiple blocks returns one block", (t) => {
 		seed: t.title,
 		withMultipleBlocks: false,
 	});
-	customModel.config.single = "paragraph";
+	if (customModel.config) {
+		customModel.config.single = "paragraph";
+	}
 
 	const actual = value.richText({
 		seed: t.title,

--- a/test/value-select.test.ts
+++ b/test/value-select.test.ts
@@ -32,5 +32,5 @@ test("supports custom model", (t) => {
 
 	const actual = value.select({ seed, model: customModel });
 
-	t.true(customModel.config.options.includes(actual));
+	t.true(customModel.config?.options?.includes(actual));
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR restores correct TypeScript types that broke as a result of switching from `@prismicio/types` to `@prismicio/client`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
