### PR TITLE
fix: treat a custom type model's `label` property as non-nullable

### DIFF
--- a/src/model/customType.ts
+++ b/src/model/customType.ts
@@ -33,11 +33,13 @@ type MockCustomTypeModel<
 	Definition extends
 		| prismic.CustomTypeModelTab
 		| prismic.CustomTypeModelDefinition,
-> = Definition extends prismic.CustomTypeModelTab
+> = (Definition extends prismic.CustomTypeModelTab
 	? prismic.CustomTypeModel<string, Record<"Main", Definition>>
 	: Definition extends prismic.CustomTypeModelDefinition
 		? prismic.CustomTypeModel<string, Definition>
-		: never;
+		: never) & {
+	label: NonNullable<prismic.CustomTypeModel["label"]>;
+};
 
 export const customType = <
 	Definition extends
@@ -60,7 +62,7 @@ export const customType = <
 
 	const format = config.format ?? faker.randomElement(["page", "custom"]);
 
-	let json = {} as MockCustomTypeModel<Definition>["json"];
+	let json = {} as prismic.CustomTypeModelDefinition;
 
 	if ("fields" in config && config.fields) {
 		json = { Main: config.fields } as typeof json;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR modifies the return value of `model.customType()` to ensure its `label` property is non-nullable.

The existing generator already ensured a value was provided.

**Before**:

```ts
{
  label: string | null | undefined;
}
```

**After**:

```ts
{
  label: string;
}
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
