### PR TITLE
feat!: change to ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.6.0-alpha.1](https://github.com/prismicio/prismic-mock/compare/v0.5.0...v0.6.0-alpha.1) (2024-12-16)
+
+
+### Features
+
+* add `"type": "module"` ([62ccfe5](https://github.com/prismicio/prismic-mock/commit/62ccfe50239fc3581dd0c729c42e39908c39512e))
+
+
+### Refactor
+
+* remove `change-case` dependency ([10fb86b](https://github.com/prismicio/prismic-mock/commit/10fb86b8031f617339cc03e5ab41c43d879cd584))
+
+
+### Chore
+
+* update version to latest alpha ([ba3fdc6](https://github.com/prismicio/prismic-mock/commit/ba3fdc672cd7a0716db0da1041362412be102f8e))
+
 ## [0.5.0](https://github.com/prismicio/prismic-mock/compare/v0.5.0-alpha.1...v0.5.0) (2024-12-05)
 
 ## [0.5.0-alpha.1](https://github.com/prismicio/prismic-mock/compare/v0.5.0-alpha.0...v0.5.0-alpha.1) (2024-11-28)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "@prismicio/mock",
 			"version": "0.5.0",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"change-case": "^5.4.4"
-			},
 			"devDependencies": {
 				"@prismicio/client": "7.11.0",
 				"@size-limit/preset-small-lib": "^11.1.2",
@@ -2402,11 +2399,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
-		},
-		"node_modules/change-case": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-			"integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="
 		},
 		"node_modules/character-entities": {
 			"version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prismicio/mock",
-	"version": "0.6.0-alpha.0",
+	"version": "0.6.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prismicio/mock",
-			"version": "0.6.0-alpha.0",
+			"version": "0.6.0-alpha.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@prismicio/client": "7.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prismicio/mock",
-	"version": "0.5.0",
+	"version": "0.6.0-alpha.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prismicio/mock",
-			"version": "0.5.0",
+			"version": "0.6.0-alpha.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@prismicio/client": "7.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@prismicio/mock",
-	"version": "0.5.0",
+	"version": "0.6.0-alpha.0",
 	"description": "Generate mock Prismic documents, fields, Slices, and models for development and testing environments",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,6 @@
 		"unit": "nyc --reporter=lcovonly --reporter=text --exclude-after-remap=false ava",
 		"unit:watch": "npm run unit -- --watch"
 	},
-	"dependencies": {
-		"change-case": "^5.4.4"
-	},
 	"devDependencies": {
 		"@prismicio/client": "7.11.0",
 		"@size-limit/preset-small-lib": "^11.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@prismicio/mock",
-	"version": "0.6.0-alpha.0",
+	"version": "0.6.0-alpha.1",
 	"description": "Generate mock Prismic documents, fields, Slices, and models for development and testing environments",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"license": "Apache-2.0",
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",
 	"sideEffects": false,
+	"type": "module",
 	"exports": {
 		".": {
 			"require": "./dist/index.cjs",

--- a/src/api/ref.ts
+++ b/src/api/ref.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 import { MockRestApiConfig } from "../types";
 import { timestamp } from "../value";
@@ -29,7 +29,7 @@ export const ref = <IsScheduled extends boolean = false>(
 		isMasterRef: config.isMasterRef ?? false,
 		label: config.isMasterRef
 			? "Master"
-			: changeCase.capitalCase(faker.words(faker.range(1, 3))),
+			: capitalCase(faker.words(faker.range(1, 3))),
 	};
 
 	if (config.isScheduled) {

--- a/src/api/repository.ts
+++ b/src/api/repository.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 import { generateTags } from "../lib/generateTags";
 
@@ -36,7 +36,7 @@ export const repository = (
 		languages: [
 			{
 				id: faker.word(),
-				name: changeCase.capitalCase(faker.word()),
+				name: capitalCase(faker.word()),
 				is_master: true,
 			},
 		],

--- a/src/lib/buildImageFieldImage.ts
+++ b/src/lib/buildImageFieldImage.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../lib/changeCase";
 import { createFaker, Faker } from "../lib/createFaker";
 
 import { MockValueStateConfig, MockImageData, Seed } from "../types";
@@ -55,8 +55,8 @@ export const buildImageFieldImage = <
 			id: faker.hash(11),
 			url: url.toString(),
 			dimensions,
-			alt: changeCase.sentenceCase(faker.words(faker.range(5, 15))),
-			copyright: changeCase.sentenceCase(faker.words(faker.range(5, 15))),
+			alt: sentenceCase(faker.words(faker.range(5, 15))),
+			copyright: sentenceCase(faker.words(faker.range(5, 15))),
 			edit: {
 				x: faker.range(-dimensions.width / 2, dimensions.width / 2),
 				y: faker.range(-dimensions.width / 2, dimensions.height / 2),

--- a/src/lib/changeCase.ts
+++ b/src/lib/changeCase.ts
@@ -1,0 +1,14 @@
+export const capitalCase = (input: string) =>
+	stripPunctuation(input).replace(/(^\w|\s\w)/g, (char) => char.toUpperCase());
+
+export const snakeCase = (input: string) =>
+	stripPunctuation(input).toLowerCase().replace(/\s/g, "_");
+
+export const sentenceCase = (input: string) =>
+	stripPunctuation(input).replace(/^./, (char) => char.toUpperCase());
+
+export const pascalCase = (input: string) =>
+	capitalCase(stripPunctuation(input.replace(/-|_/, " "))).replace(/ /g, "");
+
+const stripPunctuation = (input: string) =>
+	input.replace(/[^\p{L}\p{N}\s]/gu, "");

--- a/src/lib/generateCustomTypeId.ts
+++ b/src/lib/generateCustomTypeId.ts
@@ -1,5 +1,4 @@
-import * as changeCase from "change-case";
-
+import { snakeCase } from "../lib/changeCase";
 import { createFaker, Faker } from "../lib/createFaker";
 
 import { Seed } from "../types";
@@ -17,5 +16,5 @@ type GenerateFieldIdConfig =
 export const generateCustomTypeId = (config: GenerateFieldIdConfig): string => {
 	const faker = config.faker || createFaker(config.seed);
 
-	return changeCase.snakeCase(faker.words(faker.range(1, 3)));
+	return snakeCase(faker.words(faker.range(1, 3)));
 };

--- a/src/lib/generateFieldId.ts
+++ b/src/lib/generateFieldId.ts
@@ -1,5 +1,4 @@
-import * as changeCase from "change-case";
-
+import { snakeCase } from "../lib/changeCase";
 import { createFaker, Faker } from "../lib/createFaker";
 
 import { Seed } from "../types";
@@ -17,5 +16,5 @@ type GenerateFieldIdConfig =
 export const generateFieldId = (config: GenerateFieldIdConfig): string => {
 	const faker = config.faker || createFaker(config.seed);
 
-	return changeCase.snakeCase(faker.words(faker.range(1, 3)));
+	return snakeCase(faker.words(faker.range(1, 3)));
 };

--- a/src/lib/generateTags.ts
+++ b/src/lib/generateTags.ts
@@ -1,5 +1,4 @@
-import * as changeCase from "change-case";
-
+import { capitalCase } from "../lib/changeCase";
 import { createFaker, Faker } from "../lib/createFaker";
 
 import { Seed } from "../types";
@@ -23,6 +22,6 @@ export const generateTags = (config: GenerateTagsConfig): string[] => {
 
 	return Array.from(
 		{ length: faker.range(config.min ?? 0, config.max ?? 2) },
-		() => changeCase.capitalCase(faker.words(faker.range(1, 3))),
+		() => capitalCase(faker.words(faker.range(1, 3))),
 	);
 };

--- a/src/model/boolean.ts
+++ b/src/model/boolean.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,7 +15,7 @@ export function boolean(
 	return {
 		type: prismic.CustomTypeModelFieldType.Boolean,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
+			label: capitalCase(faker.word()),
 		},
 	};
 }

--- a/src/model/color.ts
+++ b/src/model/color.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const color = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Color,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/model/contentRelationship.ts
+++ b/src/model/contentRelationship.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -24,8 +24,8 @@ export const contentRelationship = <
 	return {
 		type: prismic.CustomTypeModelFieldType.Link,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 			select: prismic.CustomTypeModelLinkSelectType.Document,
 			customtypes: config.customTypeIDs,
 			tags: config.tags,

--- a/src/model/customType.ts
+++ b/src/model/customType.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, snakeCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -51,13 +51,13 @@ export const customType = <
 	const faker = config.faker || createFaker(config.seed);
 
 	let label: string =
-		config.label || changeCase.capitalCase(faker.words(faker.range(1, 2)));
-	let id: string = config.id || changeCase.snakeCase(label);
+		config.label || capitalCase(faker.words(faker.range(1, 2)));
+	let id: string = config.id || snakeCase(label);
 
 	if (config.id && !config.label) {
-		label = changeCase.capitalCase(config.id);
+		label = capitalCase(config.id);
 	} else if (config.label && !config.label) {
-		id = changeCase.snakeCase(config.label);
+		id = snakeCase(config.label);
 	}
 
 	const format = config.format ?? faker.randomElement(["page", "custom"]);

--- a/src/model/date.ts
+++ b/src/model/date.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const date = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Date,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/model/embed.ts
+++ b/src/model/embed.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const embed = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Embed,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/model/geoPoint.ts
+++ b/src/model/geoPoint.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,7 +15,7 @@ export const geoPoint = (
 	return {
 		type: prismic.CustomTypeModelFieldType.GeoPoint,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
+			label: capitalCase(faker.word()),
 		},
 	};
 };

--- a/src/model/group.ts
+++ b/src/model/group.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { GroupFieldModelMap, MockModelConfig } from "../types";
@@ -17,7 +17,7 @@ export function group<Fields extends GroupFieldModelMap>(
 	return {
 		type: prismic.CustomTypeModelFieldType.Group,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
+			label: capitalCase(faker.word()),
 			fields: config.fields || ({} as Fields),
 		},
 	};

--- a/src/model/image.ts
+++ b/src/model/image.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -26,7 +26,7 @@ export const image = <ThumbnailNames extends string = string>(
 	return {
 		type: prismic.CustomTypeModelFieldType.Image,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
+			label: capitalCase(faker.word()),
 			constraint: {
 				width: config.withConstraint ? faker.range(500, 2000) : null,
 				height: config.withConstraint ? faker.range(500, 2000) : null,

--- a/src/model/integration.ts
+++ b/src/model/integration.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, snakeCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -17,8 +17,8 @@ export const integration = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Integration,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			catalog: config.catalog || changeCase.snakeCase(faker.words(2)),
+			label: capitalCase(faker.word()),
+			catalog: config.catalog || snakeCase(faker.words(2)),
 		},
 	};
 };

--- a/src/model/keyText.ts
+++ b/src/model/keyText.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const keyText = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Text,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/model/link.ts
+++ b/src/model/link.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -43,8 +43,8 @@ export const link = <
 	return {
 		type: prismic.CustomTypeModelFieldType.Link,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 			select: null,
 			allowTargetBlank:
 				("allowTargetBlank" in config

--- a/src/model/linkToMedia.ts
+++ b/src/model/linkToMedia.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -23,8 +23,8 @@ export const linkToMedia = <AllowText extends boolean = boolean>(
 	return {
 		type: prismic.CustomTypeModelFieldType.Link,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 			select: prismic.CustomTypeModelLinkSelectType.Media,
 			allowText:
 				("allowText" in config ? config.allowText : faker.boolean()) ||

--- a/src/model/number.ts
+++ b/src/model/number.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const number = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Number,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/model/richText.ts
+++ b/src/model/richText.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -46,8 +46,8 @@ export const richText = <WithMultipleBlocks extends boolean = boolean>(
 	return {
 		type: prismic.CustomTypeModelFieldType.StructuredText,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 			allowTargetBlank: faker.boolean() ? true : undefined,
 			...blockTypeConfig,
 		},

--- a/src/model/select.ts
+++ b/src/model/select.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -21,8 +21,8 @@ export const select = <Option extends string, DefaultOption extends Option>(
 	return {
 		type: prismic.CustomTypeModelFieldType.Select,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 			options: config.options || [],
 			default_value: config.defaultValue || undefined,
 		},

--- a/src/model/sharedSlice.ts
+++ b/src/model/sharedSlice.ts
@@ -1,6 +1,11 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import {
+	capitalCase,
+	pascalCase,
+	sentenceCase,
+	snakeCase,
+} from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -20,21 +25,20 @@ export const sharedSlice = <
 ): prismic.SharedSliceModel<string, Variation> => {
 	const faker = config.faker || createFaker(config.seed);
 
-	let name: string =
-		config.name || changeCase.capitalCase(faker.words(faker.range(1, 2)));
-	let id: string = config.id || changeCase.snakeCase(name);
+	let name: string = config.name || capitalCase(faker.words(faker.range(1, 2)));
+	let id: string = config.id || snakeCase(name);
 
 	if (config.id && !config.name) {
-		name = changeCase.pascalCase(config.id);
+		name = pascalCase(config.id);
 	} else if (config.name && !config.name) {
-		id = changeCase.snakeCase(config.name);
+		id = snakeCase(config.name);
 	}
 
 	return {
 		type: prismic.CustomTypeModelSliceType.SharedSlice,
 		id,
 		name,
-		description: changeCase.sentenceCase(faker.words(faker.range(5, 10))),
+		description: sentenceCase(faker.words(faker.range(5, 10))),
 		variations: config.variations || ([] as Variation[]),
 	};
 };

--- a/src/model/sharedSliceVariation.ts
+++ b/src/model/sharedSliceVariation.ts
@@ -1,6 +1,11 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import {
+	capitalCase,
+	pascalCase,
+	sentenceCase,
+	snakeCase,
+} from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 import { getMockImageData } from "../lib/getMockImageData";
 
@@ -30,14 +35,13 @@ export const sharedSliceVariation = <
 ): prismic.SharedSliceModelVariation<ID, PrimaryFields, ItemsFields> => {
 	const faker = config.faker || createFaker(config.seed);
 
-	let name: string =
-		config.name || changeCase.capitalCase(faker.words(faker.range(1, 2)));
-	let id: ID = config.id || (changeCase.snakeCase(name) as ID);
+	let name: string = config.name || capitalCase(faker.words(faker.range(1, 2)));
+	let id: ID = config.id || (snakeCase(name) as ID);
 
 	if (config.id && !config.name) {
-		name = changeCase.pascalCase(config.id);
+		name = pascalCase(config.id);
 	} else if (config.name && !config.name) {
-		id = changeCase.snakeCase(config.name) as ID;
+		id = snakeCase(config.name) as ID;
 	}
 
 	const imageData = getMockImageData({ faker });
@@ -45,7 +49,7 @@ export const sharedSliceVariation = <
 	return {
 		id,
 		name,
-		description: changeCase.sentenceCase(faker.words(faker.range(5, 10))),
+		description: sentenceCase(faker.words(faker.range(5, 10))),
 		docURL: faker.url(),
 		version: faker.hash(7),
 		primary: config.primaryFields || ({} as PrimaryFields),

--- a/src/model/slice.ts
+++ b/src/model/slice.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase, snakeCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig, NestedGroupFieldModelMap } from "../types";
@@ -23,12 +23,12 @@ export const slice = <
 
 	return {
 		type: prismic.CustomTypeModelSliceType.Slice,
-		icon: changeCase.snakeCase(faker.word()),
+		icon: snakeCase(faker.word()),
 		display: faker.boolean()
 			? prismic.CustomTypeModelSliceDisplay.Grid
 			: prismic.CustomTypeModelSliceDisplay.List,
-		fieldset: changeCase.capitalCase(faker.words(2)),
-		description: changeCase.sentenceCase(faker.words(faker.range(5, 10))),
+		fieldset: capitalCase(faker.words(2)),
+		description: sentenceCase(faker.words(faker.range(5, 10))),
 		repeat: config.repeatFields || ({} as RepeatFields),
 		"non-repeat": config.nonRepeatFields || ({} as NonRepeatFields),
 	};

--- a/src/model/timestamp.ts
+++ b/src/model/timestamp.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const timestamp = (
 	return {
 		type: prismic.CustomTypeModelFieldType.Timestamp,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/model/title.ts
+++ b/src/model/title.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -26,8 +26,8 @@ export const title = (
 	return {
 		type: prismic.CustomTypeModelFieldType.StructuredText,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 			single,
 			allowTargetBlank: faker.boolean() || undefined,
 		},

--- a/src/model/uid.ts
+++ b/src/model/uid.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase, sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockModelConfig } from "../types";
@@ -15,8 +15,8 @@ export const uid = (
 	return {
 		type: prismic.CustomTypeModelFieldType.UID,
 		config: {
-			label: changeCase.capitalCase(faker.word()),
-			placeholder: changeCase.sentenceCase(faker.words(3)),
+			label: capitalCase(faker.word()),
+			placeholder: sentenceCase(faker.words(3)),
 		},
 	};
 };

--- a/src/value/customType.ts
+++ b/src/value/customType.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { snakeCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 import { generateTags } from "../lib/generateTags";
 import {
@@ -64,7 +64,7 @@ export const customType = <
 	return {
 		type: model.id,
 		id: faker.hash(7),
-		uid: hasUID ? changeCase.snakeCase(faker.words(faker.range(1, 3))) : null,
+		uid: hasUID ? snakeCase(faker.words(faker.range(1, 3))) : null,
 		url: withURL ? faker.url() : null,
 		href: faker.url(),
 		lang: faker.word(),

--- a/src/value/keyText.ts
+++ b/src/value/keyText.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockValueStateConfig, MockValueConfig } from "../types";
@@ -25,6 +25,6 @@ export const keyText = <
 	const faker = config.faker || createFaker(config.seed);
 
 	return (
-		config.state === "empty" ? null : changeCase.sentenceCase(faker.words(3))
+		config.state === "empty" ? null : sentenceCase(faker.words(3))
 	) as MockKeyTextValue<State>;
 };

--- a/src/value/link.ts
+++ b/src/value/link.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockValueStateConfig, MockValueConfig } from "../types";
@@ -104,7 +104,7 @@ export const link = <
 							: undefined,
 					text:
 						config.withText ?? (model.config?.allowText && faker.boolean())
-							? changeCase.sentenceCase(faker.words(2))
+							? sentenceCase(faker.words(2))
 							: undefined,
 				} as MockLinkValue<LinkType, State>;
 			}

--- a/src/value/linkToMedia.ts
+++ b/src/value/linkToMedia.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase, snakeCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockValueStateConfig, MockValueConfig } from "../types";
@@ -41,15 +41,15 @@ export const linkToMedia = <
 		return {
 			link_type: prismic.LinkType.Media,
 			id: faker.hash(11),
-			name: `${changeCase.snakeCase(faker.words(faker.range(1, 2)))}.example`,
-			kind: changeCase.snakeCase(faker.word()),
+			name: `${snakeCase(faker.words(faker.range(1, 2)))}.example`,
+			kind: snakeCase(faker.word()),
 			url: faker.url(),
 			size: faker.range(500, 3000).toString(),
 			height: faker.range(500, 3000).toString(),
 			width: faker.range(500, 3000).toString(),
 			text:
 				config.withText ?? (model.config?.allowText && faker.boolean())
-					? changeCase.sentenceCase(faker.words(2))
+					? sentenceCase(faker.words(2))
 					: undefined,
 		} as MockLinkToMediaValue<State>;
 	}

--- a/src/value/richText/heading.ts
+++ b/src/value/richText/heading.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { capitalCase } from "../../lib/changeCase";
 import { createFaker } from "../../lib/createFaker";
 
 import { MockRichTextValueConfig } from "../../types";
@@ -85,7 +85,7 @@ export const heading = (
 
 		return {
 			type,
-			text: changeCase.capitalCase(
+			text: capitalCase(
 				faker.words(faker.range(pattern.minWords, pattern.maxWords)),
 			),
 			spans: [],

--- a/src/value/richText/list.ts
+++ b/src/value/richText/list.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../../lib/changeCase";
 import { createFaker } from "../../lib/createFaker";
 
 import { MockRichTextValueConfig } from "../../types";
@@ -41,7 +41,7 @@ export const list = (
 		.map(() => {
 			return {
 				type: prismic.RichTextNodeType.listItem,
-				text: changeCase.sentenceCase(faker.words(faker.range(5, 15))),
+				text: sentenceCase(faker.words(faker.range(5, 15))),
 				spans: [],
 			};
 		});

--- a/src/value/richText/oList.ts
+++ b/src/value/richText/oList.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../../lib/changeCase";
 import { createFaker } from "../../lib/createFaker";
 
 import { MockRichTextValueConfig } from "../../types";
@@ -41,7 +41,7 @@ export const oList = (
 		.map(() => {
 			return {
 				type: prismic.RichTextNodeType.oListItem,
-				text: changeCase.sentenceCase(faker.words(faker.range(5, 15))),
+				text: sentenceCase(faker.words(faker.range(5, 15))),
 				spans: [],
 			};
 		});

--- a/src/value/richText/paragraph.ts
+++ b/src/value/richText/paragraph.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../../lib/changeCase";
 import { createFaker } from "../../lib/createFaker";
 
 import { MockRichTextValueConfig } from "../../types";
@@ -33,7 +33,7 @@ export const paragraph = (
 
 	const text = Array.from(
 		{ length: pattern.sentenceCount },
-		() => changeCase.sentenceCase(faker.words(faker.range(5, 15))) + ".",
+		() => sentenceCase(faker.words(faker.range(5, 15))) + ".",
 	).join(" ");
 
 	return {

--- a/src/value/richText/preformatted.ts
+++ b/src/value/richText/preformatted.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { sentenceCase } from "../../lib/changeCase";
 import { createFaker } from "../../lib/createFaker";
 
 import { MockRichTextValueConfig } from "../../types";
@@ -34,7 +34,7 @@ export const preformatted = (
 	// TODO: Use code, not lorem ipsum.
 	const text = Array.from(
 		{ length: pattern.sentenceCount },
-		() => changeCase.sentenceCase(faker.words(faker.range(5, 15))) + ".",
+		() => sentenceCase(faker.words(faker.range(5, 15))) + ".",
 	).join(" ");
 
 	return {

--- a/src/value/slice.ts
+++ b/src/value/slice.ts
@@ -1,8 +1,8 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
 import { MockValueConfig, ModelValue } from "../types";
 
+import { capitalCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 import { generateFieldId } from "../lib/generateFieldId";
 import {
@@ -35,7 +35,7 @@ export const slice = <
 	const sliceLabel =
 		config.label !== undefined
 			? config.label
-			: changeCase.capitalCase(faker.words(faker.range(1, 2)));
+			: capitalCase(faker.words(faker.range(1, 2)));
 
 	const itemsCount =
 		model.repeat && Object.keys(model.repeat).length > 0

--- a/src/value/uid.ts
+++ b/src/value/uid.ts
@@ -1,6 +1,6 @@
 import * as prismic from "@prismicio/client";
-import * as changeCase from "change-case";
 
+import { snakeCase } from "../lib/changeCase";
 import { createFaker } from "../lib/createFaker";
 
 import { MockValueConfig } from "../types";
@@ -18,5 +18,5 @@ export const uid = <
 ): NonNullable<prismic.PrismicDocument["uid"]> => {
 	const faker = config.faker || createFaker(config.seed);
 
-	return changeCase.snakeCase(faker.words(faker.range(1, 3)));
+	return snakeCase(faker.words(faker.range(1, 3)));
 };

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -2,5 +2,5 @@ import { defineConfig } from "vite";
 import sdk from "vite-plugin-sdk";
 
 export default defineConfig({
-	plugins: [sdk({ internalDependencies: ["change-case"] })],
+	plugins: [sdk()],
 });


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: #28

### Description

This PR marks `@prismicio/mock` as an ES Module via `"type": "module"`.

See the motivation behind the change in #28.

#### `change-case` removal

This PR replaces the `change-case` dependency with a simplified internal version. `@prismicio/mock` now has no dependencies (however, it retains the `@prismicio/client` peer dependency).

This change was motivated by #28, in which `@prismicio/mock` needed `"type": "module"` for Playwright compatibility. To avoid weird ESM juggling between dependencies, we can remove the only dependency: `change-case`.

All mock output should be practically identical from before. There may be slight differences in edge cases, but the output should be 100% compatible.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
